### PR TITLE
Try to improve container names and volume names rendering

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -228,7 +228,7 @@ export function App() {
         ddClient.desktopUI.toast.error(output.stderr);
       }
 
-      return output.stdout;
+      return output.stdout.trim();
     } catch (error) {
       ddClient.desktopUI.toast.error(
         `Failed to get containers for volume ${volumeName}: ${error.stderr} Error code: ${error.code}`

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -69,16 +69,12 @@ export function App() {
 
           return (
             <div>
-              {containers.map((container) => {
-                return (
-                  <>
-                    <Typography key={container} component="span">
-                      {container}
-                    </Typography>
-                    <br />
-                  </>
-                );
-              })}
+              {containers.map((container) => (
+                  <Typography key={container}>
+                    {container}
+                  </Typography>
+                )
+              )}
             </div>
           );
         }
@@ -263,7 +259,7 @@ export function App() {
           </Box>
         )}
 
-        <div style={{ height: 400, width: "100%" }}>
+        <Box width="100%">
           <DataGrid
             rows={rows}
             columns={columns}
@@ -271,10 +267,16 @@ export function App() {
             rowsPerPageOptions={[5]}
             checkboxSelection={false}
             disableSelectionOnClick={true}
+            autoHeight
             getRowHeight={() => "auto"}
             onCellClick={handleCellClick}
+            sx={{
+              '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': { py: 1 },
+              '&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell': { py: 1 },
+              '&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell': { py: 2 },
+            }}
           />
-        </div>
+          </Box>
       </Stack>
     </>
   );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -36,27 +36,6 @@ export function App() {
       field: "volumeName",
       headerName: "Volume name",
       width: 320,
-      renderCell: (params) => {
-        return params.row.volumeLinks > 0 ? (
-          <Tooltip
-            title={`In use by ${params.row.volumeLinks} container(s)`}
-            placeholder="right"
-          >
-            <Badge
-              badgeContent={params.row.volumeLinks}
-              color="primary"
-              anchorOrigin={{
-                vertical: "top",
-                horizontal: "right",
-              }}
-            >
-              <Box m={0.5}>{params.row.volumeName}</Box>
-            </Badge>
-          </Tooltip>
-        ) : (
-          <Box m={0.5}>{params.row.volumeName}</Box>
-        );
-      },
     },
     { field: "volumeLinks", hide: true },
     {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,7 +22,7 @@ function useDockerDesktopClient() {
 export function App() {
   const [rows, setRows] = React.useState([]);
   const [volumeContainersMap, setVolumeContainersMap] = React.useState<
-    Record<string, string>
+    Record<string, string[]>
   >({});
   const [volumes, setVolumes] = React.useState([]);
   const [exportPath, setExportPath] = React.useState<string>("");
@@ -65,17 +65,15 @@ export function App() {
       width: 260,
       renderCell: (params) => {
         if (params.row.volumeContainers) {
-          const containers = params.row.volumeContainers.split("\n");
-
           return (
-            <div>
-              {containers.map((container) => (
+            <Box display="flex" flexDirection="column">
+              {params.row.volumeContainers.map((container) => (
                   <Typography key={container}>
                     {container}
                   </Typography>
                 )
               )}
-            </div>
+            </Box>
           );
         }
         return <></>;
@@ -216,7 +214,7 @@ export function App() {
     }
   };
 
-  const getContainersForVolume = async (volumeName: string) => {
+  const getContainersForVolume = async (volumeName: string): Promise<string[]> => {
     try {
       const output = await ddClient.docker.cli.exec("ps", [
         "-a",
@@ -228,7 +226,7 @@ export function App() {
         ddClient.desktopUI.toast.error(output.stderr);
       }
 
-      return output.stdout.trim();
+      return output.stdout.trim().split(" ");
     } catch (error) {
       ddClient.desktopUI.toast.error(
         `Failed to get containers for volume ${volumeName}: ${error.stderr} Error code: ${error.code}`


### PR DESCRIPTION
This PR is complementing #1 

It removes the badge and the tooltip around the volume name so that the name is truncated. Since there is the container names linked to the volume, it is less useful.
Also, it removes extra `<p>` generated by the trailing space in the container names.

<img width="1616" alt="Screenshot 2022-06-16 at 14 51 10" src="https://user-images.githubusercontent.com/212269/174073542-1c51386a-4007-4323-9cf6-9caebb32c2cd.png">
