### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 ui/build
+.idea

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install-extension: build-extension ## Install the extension
 	docker extension install $(IMAGE):$(TAG)
 
 update-extension: build-extension ## Update the extension
-	docker extension update $(IMAGE):$(TAG)
+	docker extension update $(IMAGE):$(TAG) -f
 
 prepare-buildx: ## Create buildx builder for multi-arch build, if not exists
 	docker buildx inspect $(BUILDER) || docker buildx create --name=$(BUILDER) --driver=docker-container --driver-opt=network=host

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -12,6 +12,7 @@ import {
     Layers as LayersIcon,
     PlayArrow as PlayArrowIcon,
     Upload as UploadIcon,
+    DeleteForever as DeleteForeverIcon,
 } from "@mui/icons-material";
 import ExportDialog from "./components/ExportDialog";
 import ImportDialog from "./components/ImportDialog";
@@ -20,6 +21,7 @@ import LoadDialog from "./components/LoadDialog";
 import CloneDialog from "./components/CloneDialog";
 import TransferDialog from "./components/TransferDialog";
 import RunContainerDialog from "./components/RunContainerDialog";
+import DeleteForeverDialog from "./components/DeleteForeverDialog";
 import {MyContext} from ".";
 
 const client = createDockerDesktopClient();
@@ -51,6 +53,8 @@ export function App() {
     const [openTransferDialog, setOpenTransferDialog] =
         React.useState<boolean>(false);
     const [openRunContainerDialog, setOpenRunContainerDialog] =
+        React.useState<boolean>(false);
+    const [openDeleteForeverDialog, setOpenDeleteForeverDialog] =
         React.useState<boolean>(false);
     const ddClient = useDockerDesktopClient();
 
@@ -202,6 +206,17 @@ export function App() {
                     showInMenu
                     disabled={params.row.volumeSize === "0B"}
                 />,
+                <GridActionsCellItem
+                    key={"action_delete_" + params.row.id}
+                    icon={
+                        <Tooltip title="Delete volume">
+                            <DeleteForeverIcon>Delete volume</DeleteForeverIcon>
+                        </Tooltip>
+                    }
+                    label="Delete volume"
+                    onClick={handleDelete(params.row)}
+                    showInMenu
+                />,
             ],
         },
     ];
@@ -248,6 +263,11 @@ export function App() {
     const handleEmpty = (row) => async () => {
         await emptyVolume(row.volumeName);
         await calculateVolumeSize(row.volumeName);
+    };
+
+    const handleDelete = (row) => async () => {
+        setOpenDeleteForeverDialog(true)
+        context.actions.setVolumeName(row.volumeName);
     };
 
     const handleCellClick = (params: GridCellParams) => {
@@ -471,6 +491,11 @@ export function App() {
         setOpenTransferDialog(false);
     };
 
+    const handleDeleteForeverDialogClose = () => {
+        setOpenDeleteForeverDialog(false);
+        setReloadTable(!reloadTable);
+    };
+
     return (
         <>
             <Typography variant="h3">Vackup Extension</Typography>
@@ -557,6 +582,13 @@ export function App() {
                         <TransferDialog
                             open={openTransferDialog}
                             onClose={handleTransferDialogClose}
+                        />
+                    )}
+
+                    {openDeleteForeverDialog && (
+                        <DeleteForeverDialog
+                            open={openDeleteForeverDialog}
+                            onClose={handleDeleteForeverDialogClose}
                         />
                     )}
                 </Grid>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,13 +6,13 @@ import {
     ArrowCircleDown as ArrowCircleDownIcon,
     CopyAll as CopyAllIcon,
     Delete as DeleteIcon,
+    DeleteForever as DeleteForeverIcon,
     Devices as DevicesIcon,
     Download as DownloadIcon,
     ExitToApp as ExitToAppIcon,
     Layers as LayersIcon,
     PlayArrow as PlayArrowIcon,
     Upload as UploadIcon,
-    DeleteForever as DeleteForeverIcon,
 } from "@mui/icons-material";
 import ExportDialog from "./components/ExportDialog";
 import ImportDialog from "./components/ImportDialog";
@@ -293,7 +293,7 @@ export function App() {
             ddClient.desktopUI.toast.error(
                 `Failed to recalculate volume size: ${error.stderr}`
             );
-        }finally {
+        } finally {
             let volumesSizeLoadingMapCopy = volumesSizeLoadingMap
             volumesSizeLoadingMapCopy[volumeName] = false
             setVolumesSizeLoadingMap(volumesSizeLoadingMapCopy)
@@ -468,32 +468,40 @@ export function App() {
         setOpenExportDialog(false);
     };
 
-    const handleImportDialogClose = () => {
+    const handleImportDialogClose = (actionSuccessfullyCompleted: boolean) => {
         setOpenImportDialog(false);
-        calculateVolumeSize(context.store.volumeName);
+        if (actionSuccessfullyCompleted) {
+            calculateVolumeSize(context.store.volumeName);
+        }
     };
 
     const handleSaveDialogClose = () => {
         setOpenSaveDialog(false);
     };
 
-    const handleLoadDialogClose = () => {
+    const handleLoadDialogClose = (actionSuccessfullyCompleted: boolean) => {
         setOpenLoadDialog(false);
-        calculateVolumeSize(context.store.volumeName);
+        if (actionSuccessfullyCompleted) {
+            calculateVolumeSize(context.store.volumeName);
+        }
     };
 
-    const handleCloneDialogClose = () => {
+    const handleCloneDialogClose = (actionSuccessfullyCompleted: boolean) => {
         setOpenCloneDialog(false);
-        setReloadTable(!reloadTable);
+        if (actionSuccessfullyCompleted) {
+            setReloadTable(!reloadTable);
+        }
     };
 
     const handleTransferDialogClose = () => {
         setOpenTransferDialog(false);
     };
 
-    const handleDeleteForeverDialogClose = () => {
+    const handleDeleteForeverDialogClose = (actionSuccessfullyCompleted: boolean) => {
         setOpenDeleteForeverDialog(false);
-        setReloadTable(!reloadTable);
+        if (actionSuccessfullyCompleted) {
+            setReloadTable(!reloadTable);
+        }
     };
 
     return (
@@ -588,7 +596,9 @@ export function App() {
                     {openDeleteForeverDialog && (
                         <DeleteForeverDialog
                             open={openDeleteForeverDialog}
-                            onClose={handleDeleteForeverDialogClose}
+                            onClose={(e) => {
+                                handleDeleteForeverDialogClose(e)
+                            }}
                         />
                     )}
                 </Grid>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,30 +1,17 @@
-import React, { useEffect, useContext } from "react";
+import React, {useContext, useEffect} from "react";
+import {DataGrid, GridActionsCellItem, GridCellParams,} from "@mui/x-data-grid";
+import {createDockerDesktopClient} from "@docker/extension-api-client";
+import {Backdrop, Box, CircularProgress, Grid, LinearProgress, Stack, Tooltip, Typography,} from "@mui/material";
 import {
-  DataGrid,
-  GridCellParams,
-  GridActionsCellItem,
-} from "@mui/x-data-grid";
-import { createDockerDesktopClient } from "@docker/extension-api-client";
-import {
-  Backdrop,
-  Box,
-  CircularProgress,
-  LinearProgress,
-  Stack,
-  Tooltip,
-  Typography,
-  Grid,
-} from "@mui/material";
-import {
-  Download as DownloadIcon,
-  Upload as UploadIcon,
-  Delete as DeleteIcon,
-  Layers as LayersIcon,
-  ArrowCircleDown as ArrowCircleDownIcon,
-  ExitToApp as ExitToAppIcon,
-  CopyAll as CopyAllIcon,
-  Devices as DevicesIcon,
-  PlayArrow as PlayArrowIcon,
+    ArrowCircleDown as ArrowCircleDownIcon,
+    CopyAll as CopyAllIcon,
+    Delete as DeleteIcon,
+    Devices as DevicesIcon,
+    Download as DownloadIcon,
+    ExitToApp as ExitToAppIcon,
+    Layers as LayersIcon,
+    PlayArrow as PlayArrowIcon,
+    Upload as UploadIcon,
 } from "@mui/icons-material";
 import ExportDialog from "./components/ExportDialog";
 import ImportDialog from "./components/ImportDialog";
@@ -33,468 +20,515 @@ import LoadDialog from "./components/LoadDialog";
 import CloneDialog from "./components/CloneDialog";
 import TransferDialog from "./components/TransferDialog";
 import RunContainerDialog from "./components/RunContainerDialog";
-import { MyContext } from ".";
+import {MyContext} from ".";
 
 const client = createDockerDesktopClient();
 
 function useDockerDesktopClient() {
-  return client;
+    return client;
 }
 
 export function App() {
-  const context = useContext(MyContext);
-  const [rows, setRows] = React.useState([]);
-  const [volumeContainersMap, setVolumeContainersMap] = React.useState<
-    Record<string, string[]>
-  >({});
-  const [volumes, setVolumes] = React.useState([]);
-  const [reloadTable, setReloadTable] = React.useState<boolean>(false);
-  const [loadingVolumes, setLoadingVolumes] = React.useState<boolean>(true);
+    const context = useContext(MyContext);
+    const [rows, setRows] = React.useState([]);
+    const [volumeContainersMap, setVolumeContainersMap] = React.useState<Record<string, string[]>>({});
+    const [volumes, setVolumes] = React.useState([]);
+    const [reloadTable, setReloadTable] = React.useState<boolean>(false);
+    const [loadingVolumes, setLoadingVolumes] = React.useState<boolean>(true);
 
-  const [actionInProgress, setActionInProgress] =
-    React.useState<boolean>(false);
+    const [actionInProgress, setActionInProgress] =
+        React.useState<boolean>(false);
 
-  const [openExportDialog, setOpenExportDialog] =
-    React.useState<boolean>(false);
-  const [openImportDialog, setOpenImportDialog] =
-    React.useState<boolean>(false);
-  const [openSaveDialog, setOpenSaveDialog] = React.useState<boolean>(false);
-  const [openLoadDialog, setOpenLoadDialog] = React.useState<boolean>(false);
-  const [openCloneDialog, setOpenCloneDialog] = React.useState<boolean>(false);
-  const [openTransferDialog, setOpenTransferDialog] =
-    React.useState<boolean>(false);
-  const [openRunContainerDialog, setOpenRunContainerDialog] =
-    React.useState<boolean>(false);
-  const ddClient = useDockerDesktopClient();
+    const [openExportDialog, setOpenExportDialog] =
+        React.useState<boolean>(false);
+    const [openImportDialog, setOpenImportDialog] =
+        React.useState<boolean>(false);
+    const [openSaveDialog, setOpenSaveDialog] = React.useState<boolean>(false);
+    const [openLoadDialog, setOpenLoadDialog] = React.useState<boolean>(false);
+    const [openCloneDialog, setOpenCloneDialog] = React.useState<boolean>(false);
+    const [openTransferDialog, setOpenTransferDialog] =
+        React.useState<boolean>(false);
+    const [openRunContainerDialog, setOpenRunContainerDialog] =
+        React.useState<boolean>(false);
+    const ddClient = useDockerDesktopClient();
 
-  const columns = [
-    { field: "id", headerName: "ID", width: 70, hide: true },
-    { field: "volumeDriver", headerName: "Driver" },
-    {
-      field: "volumeName",
-      headerName: "Volume name",
-      flex: 1,
-    },
-    { field: "volumeLinks", hide: true },
-    {
-      field: "volumeContainers",
-      headerName: "Containers",
-      flex: 1,
-      renderCell: (params) => {
-        if (params.row.volumeContainers) {
-          return (
-            <Box display="flex" flexDirection="column">
-              {params.row.volumeContainers.map((container) => (
-                <Typography key={container}>{container}</Typography>
-              ))}
-            </Box>
-          );
-        }
-        return <></>;
-      },
-    },
-    { field: "volumeSize", headerName: "Size" },
-    {
-      field: "actions",
-      type: "actions",
-      headerName: "Actions",
-      minWidth: 220,
-      sortable: false,
-      flex: 1,
-      getActions: (params) => [
-        <GridActionsCellItem
-          key={"action_view_volume_" + params.row.id}
-          icon={
-            <Tooltip title="View volume">
-              <ExitToAppIcon>View volume</ExitToAppIcon>
-            </Tooltip>
-          }
-          label="View volume"
-          onClick={handleNavigate(params.row)}
-          disabled={actionInProgress}
-          showInMenu
-        />,
-        <GridActionsCellItem
-          key={"action_run_container_from_volume_" + params.row.id}
-          icon={
-            <Tooltip title="Run container from volume">
-              <PlayArrowIcon>Run container from volume</PlayArrowIcon>
-            </Tooltip>
-          }
-          label="Run container from volume"
-          onClick={handleRunContainer(params.row)}
-          disabled={actionInProgress}
-        />,
-        <GridActionsCellItem
-          key={"action_clone_volume_" + params.row.id}
-          icon={
-            <Tooltip title="Clone volume">
-              <CopyAllIcon>Clone volume</CopyAllIcon>
-            </Tooltip>
-          }
-          label="Clone volume"
-          onClick={handleClone(params.row)}
-          disabled={actionInProgress}
-        />,
-        <GridActionsCellItem
-          key={"action_export_" + params.row.id}
-          icon={
-            <Tooltip title="Export volume">
-              <DownloadIcon>Export volume</DownloadIcon>
-            </Tooltip>
-          }
-          label="Export volume"
-          onClick={handleExport(params.row)}
-        />,
-        <GridActionsCellItem
-          key={"action_import_" + params.row.id}
-          icon={
-            <Tooltip title="Import gzip'ed tarball">
-              <UploadIcon>Import gzip'ed tarball</UploadIcon>
-            </Tooltip>
-          }
-          label="Import gzip'ed tarball"
-          onClick={handleImport(params.row)}
-        />,
-        <GridActionsCellItem
-          key={"action_save_" + params.row.id}
-          icon={
-            <Tooltip title="Save to image">
-              <LayersIcon>Save to image</LayersIcon>
-            </Tooltip>
-          }
-          label="Save to image"
-          onClick={handleSave(params.row)}
-          showInMenu
-        />,
-        <GridActionsCellItem
-          key={"action_load_" + params.row.id}
-          icon={
-            <Tooltip title="Load from image">
-              <ArrowCircleDownIcon>Load from image</ArrowCircleDownIcon>
-            </Tooltip>
-          }
-          label="Load from image"
-          onClick={handleLoad(params.row)}
-          showInMenu
-        />,
-        <GridActionsCellItem
-          key={"action_transfer_" + params.row.id}
-          icon={
-            <Tooltip title="Transfer to host">
-              <DevicesIcon>Transfer to host</DevicesIcon>
-            </Tooltip>
-          }
-          label="Transfer to host"
-          onClick={handleTransfer(params.row)}
-          showInMenu
-        />,
-        <GridActionsCellItem
-          key={"action_empty_" + params.row.id}
-          icon={
-            <Tooltip title="Empty volume">
-              <DeleteIcon>Empty volume</DeleteIcon>
-            </Tooltip>
-          }
-          label="Empty volume"
-          onClick={handleEmpty(params.row)}
-          showInMenu
-        />,
-      ],
-    },
-  ];
-
-  const handleNavigate = (row) => async () => {
-    ddClient.desktopUI.navigate.viewVolume(row.volumeName);
-  };
-
-  const handleRunContainer = (row) => () => {
-    setOpenRunContainerDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleClone = (row) => () => {
-    setOpenCloneDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleExport = (row) => () => {
-    setOpenExportDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleImport = (row) => () => {
-    setOpenImportDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleSave = (row) => () => {
-    setOpenSaveDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleLoad = (row) => async () => {
-    setOpenLoadDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleTransfer = (row) => async () => {
-    setOpenTransferDialog(true);
-    context.actions.setVolumeName(row.volumeName);
-  };
-
-  const handleEmpty = (row) => async () => {
-    await emptyVolume(row.volumeName);
-    setReloadTable(!reloadTable);
-  };
-
-  const handleCellClick = (params: GridCellParams) => {
-    if (params.colDef.field === "volumeName") {
-      ddClient.desktopUI.navigate.viewVolume(params.row.volumeName);
-    }
-  };
-
-  useEffect(() => {
-    const listVolumes = async () => {
-      try {
-        const result = await ddClient.docker.cli.exec("system", [
-          "df",
-          "-v",
-          "--format",
-          '"{{ json .Volumes }}"',
-        ]);
-
-        if (result.stderr !== "") {
-          ddClient.desktopUI.toast.error(result.stderr);
-        } else {
-          const volumes = result.parseJsonObject();
-
-          const promises = volumes.map((volume) =>
-            getContainersForVolume(volume.Name)
-          );
-
-          Promise.allSettled(promises)
-            .then((values) => {
-              const map = {};
-
-              values.forEach((value) => {
-                if (value.status === "rejected") {
-                  ddClient.desktopUI.toast.error(value.reason);
-                  return;
+    const columns = [
+        {field: "id", headerName: "ID", width: 70, hide: true},
+        {field: "volumeDriver", headerName: "Driver"},
+        {
+            field: "volumeName",
+            headerName: "Volume name",
+            flex: 1,
+        },
+        {field: "volumeLinks", hide: true},
+        {
+            field: "volumeContainers",
+            headerName: "Containers",
+            flex: 1,
+            renderCell: (params) => {
+                if (params.row.volumeContainers) {
+                    return (
+                        <Box display="flex" flexDirection="column">
+                            {params.row.volumeContainers.map((container) => (
+                                <Typography key={container}>{container}</Typography>
+                            ))}
+                        </Box>
+                    );
                 }
+                return <></>;
+            },
+        },
+        {field: "volumeSize", headerName: "Size"},
+        {
+            field: "actions",
+            type: "actions",
+            headerName: "Actions",
+            minWidth: 220,
+            sortable: false,
+            flex: 1,
+            getActions: (params) => [
+                <GridActionsCellItem
+                    key={"action_view_volume_" + params.row.id}
+                    icon={
+                        <Tooltip title="View volume">
+                            <ExitToAppIcon>View volume</ExitToAppIcon>
+                        </Tooltip>
+                    }
+                    label="View volume"
+                    onClick={handleNavigate(params.row)}
+                    disabled={actionInProgress}
+                    showInMenu
+                />,
+                <GridActionsCellItem
+                    key={"action_run_container_from_volume_" + params.row.id}
+                    icon={
+                        <Tooltip title="Run container from volume">
+                            <PlayArrowIcon>Run container from volume</PlayArrowIcon>
+                        </Tooltip>
+                    }
+                    label="Run container from volume"
+                    onClick={handleRunContainer(params.row)}
+                    disabled={actionInProgress}
+                />,
+                <GridActionsCellItem
+                    key={"action_clone_volume_" + params.row.id}
+                    icon={
+                        <Tooltip title="Clone volume">
+                            <CopyAllIcon>Clone volume</CopyAllIcon>
+                        </Tooltip>
+                    }
+                    label="Clone volume"
+                    onClick={handleClone(params.row)}
+                    disabled={actionInProgress}
+                />,
+                <GridActionsCellItem
+                    key={"action_export_" + params.row.id}
+                    icon={
+                        <Tooltip title="Export volume">
+                            <DownloadIcon>Export volume</DownloadIcon>
+                        </Tooltip>
+                    }
+                    label="Export volume"
+                    onClick={handleExport(params.row)}
+                    disabled={params.row.volumeSize === "0B"}
+                />,
+                <GridActionsCellItem
+                    key={"action_import_" + params.row.id}
+                    icon={
+                        <Tooltip title="Import gzip'ed tarball">
+                            <UploadIcon>Import gzip'ed tarball</UploadIcon>
+                        </Tooltip>
+                    }
+                    label="Import gzip'ed tarball"
+                    onClick={handleImport(params.row)}
+                />,
+                <GridActionsCellItem
+                    key={"action_save_" + params.row.id}
+                    icon={
+                        <Tooltip title="Save to image">
+                            <LayersIcon>Save to image</LayersIcon>
+                        </Tooltip>
+                    }
+                    label="Save to image"
+                    onClick={handleSave(params.row)}
+                    showInMenu
+                    disabled={params.row.volumeSize === "0B"}
+                />,
+                <GridActionsCellItem
+                    key={"action_load_" + params.row.id}
+                    icon={
+                        <Tooltip title="Load from image">
+                            <ArrowCircleDownIcon>Load from image</ArrowCircleDownIcon>
+                        </Tooltip>
+                    }
+                    label="Load from image"
+                    onClick={handleLoad(params.row)}
+                    showInMenu
+                />,
+                <GridActionsCellItem
+                    key={"action_transfer_" + params.row.id}
+                    icon={
+                        <Tooltip title="Transfer to host">
+                            <DevicesIcon>Transfer to host</DevicesIcon>
+                        </Tooltip>
+                    }
+                    label="Transfer to host"
+                    onClick={handleTransfer(params.row)}
+                    showInMenu
+                    disabled={params.row.volumeSize === "0B"}
+                />,
+                <GridActionsCellItem
+                    key={"action_empty_" + params.row.id}
+                    icon={
+                        <Tooltip title="Empty volume">
+                            <DeleteIcon>Empty volume</DeleteIcon>
+                        </Tooltip>
+                    }
+                    label="Empty volume"
+                    onClick={handleEmpty(params.row)}
+                    showInMenu
+                    disabled={params.row.volumeSize === "0B"}
+                />,
+            ],
+        },
+    ];
 
-                const { volumeName, containers } = value.value;
-                map[volumeName] = containers;
-              });
-
-              setVolumeContainersMap(map);
-            })
-
-            .finally(() => {
-              setLoadingVolumes(false);
-            });
-
-          setVolumes(volumes);
-        }
-      } catch (error) {
-        setLoadingVolumes(false);
-        ddClient.desktopUI.toast.error(
-          `Failed to list volumes: ${error.stderr}`
-        );
-      }
+    const handleNavigate = (row) => async () => {
+        ddClient.desktopUI.navigate.viewVolume(row.volumeName);
     };
 
-    listVolumes();
+    const handleRunContainer = (row) => () => {
+        setOpenRunContainerDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reloadTable]);
+    const handleClone = (row) => () => {
+        setOpenCloneDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
 
-  useEffect(() => {
-    const rows = volumes
-      .sort((a, b) => a.Name.localeCompare(b.Name))
-      .map((volume, index) => {
-        return {
-          id: index,
-          volumeDriver: volume.Driver,
-          volumeName: volume.Name,
-          volumeLinks: volume.Links,
-          volumeContainers: volumeContainersMap[volume.Name],
-          volumeSize: volume.Size,
+    const handleExport = (row) => () => {
+        setOpenExportDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
+
+    const handleImport = (row) => () => {
+        setOpenImportDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
+
+    const handleSave = (row) => () => {
+        setOpenSaveDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
+
+    const handleLoad = (row) => async () => {
+        setOpenLoadDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
+
+    const handleTransfer = (row) => async () => {
+        setOpenTransferDialog(true);
+        context.actions.setVolumeName(row.volumeName);
+    };
+
+    const handleEmpty = (row) => async () => {
+        await emptyVolume(row.volumeName);
+        await calculateVolumeSize(row.volumeName);
+    };
+
+    const handleCellClick = (params: GridCellParams) => {
+        if (params.colDef.field === "volumeName") {
+            ddClient.desktopUI.navigate.viewVolume(params.row.volumeName);
+        }
+    };
+
+    const calculateVolumeSize = async (volumeName: string) => {
+        const tmpDir = "/recalc-vol-size"
+        try {
+            // e.g. docker run --rm -v postgres-vol:/pgdata alpine /bin/sh -c  "du -d 0 -h /pgdata | cut -f 1"
+            // get only dir size, without the name, e.g:
+            // 41.5M
+            // instead of
+            // 41.5M	/pgdata
+            const args = [
+                "--rm",
+                `-v=${volumeName}:${tmpDir}`,
+                "alpine",
+                "/bin/sh",
+                "-c",
+                `"du -d 0 -h ${tmpDir}"`
+            ];
+            const result = await ddClient.docker.cli.exec("run", args);
+
+            if (result.stderr !== "") {
+                ddClient.desktopUI.toast.error(result.stderr);
+            } else {
+                const s = result.lines()[0].split("\t"); // e.g. 41.5M	/recalc-vol-size
+                let size = s[0]
+
+                if (size === "4.0K") {
+                    // If a directory size is 4K, it is in fact "empty".
+                    // The metadata of the folder is stored in blocks and 4K is the minimum filesystem's block size.
+                    // Therefore, we set it to "0B" to indicate that the directory is empty.
+                    size = "0B"
+                }
+
+                let rowsCopy = rows.slice() // copy the array
+                const index = rowsCopy.findIndex(element => element.volumeName === volumeName)
+                rowsCopy[index].volumeSize = size
+
+                setRows(rowsCopy)
+            }
+        } catch (error) {
+            setLoadingVolumes(false);
+            ddClient.desktopUI.toast.error(
+                `Failed to recalculate volume size: ${error.stderr}`
+            );
+        }
+    };
+
+    useEffect(() => {
+        const listVolumes = async () => {
+            try {
+                const result = await ddClient.docker.cli.exec("system", [
+                    "df",
+                    "-v",
+                    "--format",
+                    '"{{ json .Volumes }}"',
+                ]);
+
+                if (result.stderr !== "") {
+                    ddClient.desktopUI.toast.error(result.stderr);
+                } else {
+                    const volumes = result.parseJsonObject();
+
+                    const promises = volumes.map((volume) =>
+                        getContainersForVolume(volume.Name)
+                    );
+
+                    Promise.allSettled(promises)
+                        .then((values) => {
+                            const map = {};
+
+                            values.forEach((value) => {
+                                if (value.status === "rejected") {
+                                    ddClient.desktopUI.toast.error(value.reason);
+                                    return;
+                                }
+
+                                const {volumeName, containers} = value.value;
+                                map[volumeName] = containers;
+                            });
+
+                            setVolumeContainersMap(map);
+                        })
+
+                        .finally(() => {
+                            setLoadingVolumes(false);
+                        });
+
+                    setVolumes(volumes);
+                }
+            } catch (error) {
+                setLoadingVolumes(false);
+                ddClient.desktopUI.toast.error(
+                    `Failed to list volumes: ${error.stderr}`
+                );
+            }
         };
-      });
 
-    setRows(rows);
-  }, [volumeContainersMap]);
+        listVolumes();
 
-  const emptyVolume = async (volumeName: string) => {
-    setActionInProgress(true);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [reloadTable]);
 
-    try {
-      const output = await ddClient.docker.cli.exec("run", [
-        "--rm",
-        `-v=${volumeName}:/vackup-volume `,
-        "busybox",
-        "/bin/sh",
-        "-c",
-        '"rm -rf /vackup-volume/..?* /vackup-volume/.[!.]* /vackup-volume/*"', // hidden and not-hidden files and folders: .[!.]* matches all dot files except . and files whose name begins with .., and ..?* matches all dot-dot files except ..
-      ]);
-      if (output.stderr !== "") {
-        ddClient.desktopUI.toast.error(output.stderr);
-        return;
-      }
-      ddClient.desktopUI.toast.success(
-        `The content of volume ${volumeName} has been removed`
-      );
-    } catch (error) {
-      ddClient.desktopUI.toast.error(
-        `Failed to empty volume ${volumeName}: ${error.stderr} Exit code: ${error.code}`
-      );
-    } finally {
-      setActionInProgress(false);
-    }
-  };
+    useEffect(() => {
+        const rows = volumes
+            .sort((a, b) => a.Name.localeCompare(b.Name))
+            .map((volume, index) => {
+                return {
+                    id: index,
+                    volumeDriver: volume.Driver,
+                    volumeName: volume.Name,
+                    volumeLinks: volume.Links,
+                    volumeContainers: volumeContainersMap[volume.Name],
+                    volumeSize: volume.Size,
+                };
+            });
 
-  const getContainersForVolume = async (
-    volumeName: string
-  ): Promise<{ volumeName: string; containers: string[] }> => {
-    try {
-      const output = await ddClient.docker.cli.exec("ps", [
-        "-a",
-        `--filter="volume=${volumeName}"`,
-        `--format="{{ .Names}}"`,
-      ]);
+        setRows(rows);
+    }, [volumeContainersMap]);
 
-      if (output.stderr !== "") {
-        ddClient.desktopUI.toast.error(output.stderr);
-      }
+    const emptyVolume = async (volumeName: string) => {
+        setActionInProgress(true);
 
-      return { volumeName, containers: output.stdout.trim().split(" ") };
-    } catch (error) {
-      const errorMsg = `Failed to get containers for volume ${volumeName}: ${error.stderr} Error code: ${error.code}`;
-      return Promise.reject(errorMsg);
-    }
-  };
+        try {
+            const output = await ddClient.docker.cli.exec("run", [
+                "--rm",
+                `-v=${volumeName}:/vackup-volume `,
+                "busybox",
+                "/bin/sh",
+                "-c",
+                '"rm -rf /vackup-volume/..?* /vackup-volume/.[!.]* /vackup-volume/*"', // hidden and not-hidden files and folders: .[!.]* matches all dot files except . and files whose name begins with .., and ..?* matches all dot-dot files except ..
+            ]);
+            if (output.stderr !== "") {
+                ddClient.desktopUI.toast.error(output.stderr);
+                return;
+            }
+            ddClient.desktopUI.toast.success(
+                `The content of volume ${volumeName} has been removed`
+            );
+        } catch (error) {
+            ddClient.desktopUI.toast.error(
+                `Failed to empty volume ${volumeName}: ${error.stderr} Exit code: ${error.code}`
+            );
+        } finally {
+            setActionInProgress(false);
+        }
+    };
 
-  const handleRunContainerDialogClose = () => {
-    setOpenRunContainerDialog(false);
-  };
+    const getContainersForVolume = async (
+        volumeName: string
+    ): Promise<{ volumeName: string; containers: string[] }> => {
+        try {
+            const output = await ddClient.docker.cli.exec("ps", [
+                "-a",
+                `--filter="volume=${volumeName}"`,
+                `--format="{{ .Names}}"`,
+            ]);
 
-  const handleExportDialogClose = () => {
-    setOpenExportDialog(false);
-  };
+            if (output.stderr !== "") {
+                ddClient.desktopUI.toast.error(output.stderr);
+            }
 
-  const handleImportDialogClose = () => {
-    setOpenImportDialog(false);
-    setReloadTable(!reloadTable);
-  };
+            return {volumeName, containers: output.stdout.trim().split(" ")};
+        } catch (error) {
+            const errorMsg = `Failed to get containers for volume ${volumeName}: ${error.stderr} Error code: ${error.code}`;
+            return Promise.reject(errorMsg);
+        }
+    };
 
-  const handleSaveDialogClose = () => {
-    setOpenSaveDialog(false);
-  };
+    const handleRunContainerDialogClose = () => {
+        setOpenRunContainerDialog(false);
+    };
 
-  const handleLoadDialogClose = () => {
-    setOpenLoadDialog(false);
-    setReloadTable(!reloadTable);
-  };
+    const handleExportDialogClose = () => {
+        setOpenExportDialog(false);
+    };
 
-  const handleCloneDialogClose = () => {
-    setOpenCloneDialog(false);
-  };
+    const handleImportDialogClose = () => {
+        setOpenImportDialog(false);
+        calculateVolumeSize(context.store.volumeName);
+    };
 
-  const handleTransferDialogClose = () => {
-    setOpenTransferDialog(false);
-  };
+    const handleSaveDialogClose = () => {
+        setOpenSaveDialog(false);
+    };
 
-  return (
-    <>
-      <Typography variant="h3">Vackup Extension</Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ mt: 2 }}>
-        Easily backup and restore docker volumes.
-      </Typography>
-      <Stack direction="column" alignItems="start" spacing={2} sx={{ mt: 4 }}>
-        <Grid container>
-          <Grid item flex={1}>
-            <Backdrop
-              sx={{
-                backgroundColor: "rgba(245,244,244,0.4)",
-                zIndex: (theme) => theme.zIndex.drawer + 1,
-              }}
-              open={actionInProgress}
-            >
-              <CircularProgress color="info" />
-            </Backdrop>
-            <DataGrid
-              loading={loadingVolumes}
-              components={{
-                LoadingOverlay: LinearProgress,
-              }}
-              rows={rows}
-              columns={columns}
-              pageSize={10}
-              rowsPerPageOptions={[10]}
-              checkboxSelection={false}
-              disableSelectionOnClick={true}
-              autoHeight
-              getRowHeight={() => "auto"}
-              onCellClick={handleCellClick}
-              sx={{
-                "&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell": {
-                  py: 1,
-                },
-                "&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell": {
-                  py: 1,
-                },
-                "&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell": {
-                  py: 2,
-                },
-              }}
-            />
-          </Grid>
+    const handleLoadDialogClose = () => {
+        setOpenLoadDialog(false);
+        calculateVolumeSize(context.store.volumeName);
+    };
 
-          {openRunContainerDialog && (
-            <RunContainerDialog
-              open={openRunContainerDialog}
-              onClose={handleRunContainerDialogClose}
-            />
-          )}
+    const handleCloneDialogClose = () => {
+        setOpenCloneDialog(false);
+    };
 
-          {openExportDialog && (
-            <ExportDialog
-              open={openExportDialog}
-              onClose={handleExportDialogClose}
-            />
-          )}
+    const handleTransferDialogClose = () => {
+        setOpenTransferDialog(false);
+    };
 
-          {openImportDialog && (
-            <ImportDialog
-              open={openImportDialog}
-              onClose={handleImportDialogClose}
-            />
-          )}
+    return (
+        <>
+            <Typography variant="h3">Vackup Extension</Typography>
+            <Typography variant="body1" color="text.secondary" sx={{mt: 2}}>
+                Easily backup and restore docker volumes.
+            </Typography>
+            <Stack direction="column" alignItems="start" spacing={2} sx={{mt: 4}}>
+                <Grid container>
+                    <Grid item flex={1}>
+                        <Backdrop
+                            sx={{
+                                backgroundColor: "rgba(245,244,244,0.4)",
+                                zIndex: (theme) => theme.zIndex.drawer + 1,
+                            }}
+                            open={actionInProgress}
+                        >
+                            <CircularProgress color="info"/>
+                        </Backdrop>
+                        <DataGrid
+                            loading={loadingVolumes}
+                            components={{
+                                LoadingOverlay: LinearProgress,
+                            }}
+                            rows={rows}
+                            columns={columns}
+                            pageSize={10}
+                            rowsPerPageOptions={[10]}
+                            checkboxSelection={false}
+                            disableSelectionOnClick={true}
+                            autoHeight
+                            getRowHeight={() => "auto"}
+                            onCellClick={handleCellClick}
+                            sx={{
+                                "&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell": {
+                                    py: 1,
+                                },
+                                "&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell": {
+                                    py: 1,
+                                },
+                                "&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell": {
+                                    py: 2,
+                                },
+                            }}
+                        />
+                    </Grid>
 
-          {openSaveDialog && (
-            <SaveDialog open={openSaveDialog} onClose={handleSaveDialogClose} />
-          )}
+                    {openRunContainerDialog && (
+                        <RunContainerDialog
+                            open={openRunContainerDialog}
+                            onClose={handleRunContainerDialogClose}
+                        />
+                    )}
 
-          {openLoadDialog && (
-            <LoadDialog open={openLoadDialog} onClose={handleLoadDialogClose} />
-          )}
+                    {openExportDialog && (
+                        <ExportDialog
+                            open={openExportDialog}
+                            onClose={handleExportDialogClose}
+                        />
+                    )}
 
-          {openCloneDialog && (
-            <CloneDialog
-              open={openCloneDialog}
-              onClose={handleCloneDialogClose}
-            />
-          )}
+                    {openImportDialog && (
+                        <ImportDialog
+                            open={openImportDialog}
+                            onClose={handleImportDialogClose}
+                        />
+                    )}
 
-          {openTransferDialog && (
-            <TransferDialog
-              open={openTransferDialog}
-              onClose={handleTransferDialogClose}
-            />
-          )}
-        </Grid>
-      </Stack>
-    </>
-  );
+                    {openSaveDialog && (
+                        <SaveDialog open={openSaveDialog} onClose={handleSaveDialogClose}/>
+                    )}
+
+                    {openLoadDialog && (
+                        <LoadDialog open={openLoadDialog} onClose={handleLoadDialogClose}/>
+                    )}
+
+                    {openCloneDialog && (
+                        <CloneDialog
+                            open={openCloneDialog}
+                            onClose={handleCloneDialogClose}
+                        />
+                    )}
+
+                    {openTransferDialog && (
+                        <TransferDialog
+                            open={openTransferDialog}
+                            onClose={handleTransferDialogClose}
+                        />
+                    )}
+                </Grid>
+            </Stack>
+        </>
+    );
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -335,8 +335,30 @@ export function App() {
         return size
     }
 
+    // This useEffect will pull the alpine image as it is needed to compute each volume size.
+    useEffect(() => {
+        const pullAlpineImage = async() => {
+            const startTime = performance.now()
+
+            const result = await ddClient.docker.cli.exec("pull", [
+                "alpine",
+            ]);
+
+            if (result.stderr !== "") {
+                ddClient.desktopUI.toast.error(result.stderr);
+                return
+            }
+
+            const endTime = performance.now()
+            console.log(`[pullAlpineImage] took ${endTime - startTime} ms.`)
+        }
+
+        pullAlpineImage()
+    }, [])
+
     useEffect(() => {
         const listVolumes = async () => {
+            const startTime = performance.now()
             setLoadingVolumes(true);
             try {
                 const result = await ddClient.docker.cli.exec("volume", [
@@ -375,6 +397,8 @@ export function App() {
 
                         .finally(() => {
                             setLoadingVolumes(false);
+                            const endTime = performance.now()
+                            console.log(`[listVolumes] took ${endTime - startTime} ms.`)
                         });
 
                     setVolumes(volumes);
@@ -393,6 +417,8 @@ export function App() {
     }, [reloadTable]);
 
     useEffect(() => {
+        const startTime = performance.now()
+
         const rows = volumes
             .sort((a, b) => a.Name.localeCompare(b.Name))
             .map((volume, index) => {
@@ -407,6 +433,9 @@ export function App() {
             });
 
         setRows(rows);
+
+        const endTime = performance.now()
+        console.log(`[setRows] took ${endTime - startTime} ms.`)
     }, [volumeContainersMap, volumeSizeMap]);
 
     const emptyVolume = async (volumeName: string) => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,7 @@ import TransferDialog from "./components/TransferDialog";
 import RunContainerDialog from "./components/RunContainerDialog";
 import DeleteForeverDialog from "./components/DeleteForeverDialog";
 import {MyContext} from ".";
+import {isError} from "./common/isError";
 
 const client = createDockerDesktopClient();
 
@@ -319,7 +320,7 @@ export function App() {
         ];
         const result = await ddClient.docker.cli.exec("run", args);
 
-        if (result.stderr !== "") {
+        if (isError(result.stderr)) {
             ddClient.desktopUI.toast.error(result.stderr);
         } else {
             const s = result.lines()[0].split("\t"); // e.g. 41.5M	/recalc-vol-size
@@ -344,7 +345,7 @@ export function App() {
                 "alpine",
             ]);
 
-            if (result.stderr !== "") {
+            if (isError(result.stderr)) {
                 ddClient.desktopUI.toast.error(result.stderr);
                 return
             }
@@ -450,7 +451,7 @@ export function App() {
                 "-c",
                 '"rm -rf /vackup-volume/..?* /vackup-volume/.[!.]* /vackup-volume/*"', // hidden and not-hidden files and folders: .[!.]* matches all dot files except . and files whose name begins with .., and ..?* matches all dot-dot files except ..
             ]);
-            if (output.stderr !== "") {
+            if (isError(output.stderr)) {
                 ddClient.desktopUI.toast.error(output.stderr);
                 return;
             }

--- a/ui/src/components/CloneDialog.tsx
+++ b/ui/src/components/CloneDialog.tsx
@@ -35,6 +35,7 @@ export default function CloneDialog({ ...props }) {
 
   const cloneVolume = async () => {
     setActionInProgress(true);
+    let actionSuccessfullyCompleted = false
 
     try {
       // TODO: check if destination volume already exists
@@ -64,13 +65,15 @@ export default function CloneDialog({ ...props }) {
       ddClient.desktopUI.toast.success(
         `Volume ${context.store.volumeName} cloned to destination volume ${volumeName}`
       );
+
+      actionSuccessfullyCompleted = true
     } catch (error) {
       ddClient.desktopUI.toast.error(
         `Failed to clone volume ${context.store.volumeName} to destinaton volume ${volumeName}: ${error.stderr} Exit code: ${error.code}`
       );
     } finally {
       setActionInProgress(false);
-      props.onClose();
+      props.onClose(actionSuccessfullyCompleted)
     }
   };
 
@@ -117,7 +120,7 @@ export default function CloneDialog({ ...props }) {
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.onClose}>Cancel</Button>
+        <Button onClick={() => props.onClose(false)}>Cancel</Button>
         <Button onClick={cloneVolume} disabled={volumeName === ""}>
           Clone
         </Button>

--- a/ui/src/components/DeleteForeverDialog.tsx
+++ b/ui/src/components/DeleteForeverDialog.tsx
@@ -1,9 +1,6 @@
 import React, { useContext } from "react";
 import {
   Button,
-  TextField,
-  Typography,
-  Grid,
   Backdrop,
   CircularProgress,
 } from "@mui/material";
@@ -15,7 +12,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 import { MyContext } from "../index";
-import { isError } from "../common/isError";
 
 const client = createDockerDesktopClient();
 
@@ -32,6 +28,7 @@ export default function DeleteForeverDialog({ ...props }) {
 
   const deleteVolume = async () => {
     setActionInProgress(true);
+    let actionSuccessfullyCompleted = false
 
     try {
       // TODO: check if volume already exists
@@ -47,13 +44,15 @@ export default function DeleteForeverDialog({ ...props }) {
       ddClient.desktopUI.toast.success(
         `Volume ${context.store.volumeName} deleted`
       );
+
+      actionSuccessfullyCompleted = true
     } catch (error) {
       ddClient.desktopUI.toast.error(
         `Failed to delete volume ${context.store.volumeName}: ${error.stderr} Exit code: ${error.code}`
       );
     } finally {
       setActionInProgress(false);
-      props.onClose();
+      props.onClose(actionSuccessfullyCompleted)
     }
   };
 
@@ -73,7 +72,7 @@ export default function DeleteForeverDialog({ ...props }) {
         <DialogContentText>The volume will be deleted permanently. This action cannot be undone. Are you sure?</DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.onClose}>Cancel</Button>
+        <Button onClick={() => props.onClose(false)}>Cancel</Button>
         <Button onClick={deleteVolume}>
           Delete forever
         </Button>

--- a/ui/src/components/DeleteForeverDialog.tsx
+++ b/ui/src/components/DeleteForeverDialog.tsx
@@ -1,0 +1,83 @@
+import React, { useContext } from "react";
+import {
+  Button,
+  TextField,
+  Typography,
+  Grid,
+  Backdrop,
+  CircularProgress,
+} from "@mui/material";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
+
+import { MyContext } from "../index";
+import { isError } from "../common/isError";
+
+const client = createDockerDesktopClient();
+
+function useDockerDesktopClient() {
+  return client;
+}
+
+export default function DeleteForeverDialog({ ...props }) {
+  const ddClient = useDockerDesktopClient();
+  const context = useContext(MyContext);
+
+  const [actionInProgress, setActionInProgress] =
+    React.useState<boolean>(false);
+
+  const deleteVolume = async () => {
+    setActionInProgress(true);
+
+    try {
+      // TODO: check if volume already exists
+      const output = await ddClient.docker.cli.exec("volume", [
+        "rm",
+        context.store.volumeName,
+      ]);
+      if (output.stderr !== "") {
+        ddClient.desktopUI.toast.error(output.stderr);
+        return;
+      }
+
+      ddClient.desktopUI.toast.success(
+        `Volume ${context.store.volumeName} deleted`
+      );
+    } catch (error) {
+      ddClient.desktopUI.toast.error(
+        `Failed to delete volume ${context.store.volumeName}: ${error.stderr} Exit code: ${error.code}`
+      );
+    } finally {
+      setActionInProgress(false);
+      props.onClose();
+    }
+  };
+
+  return (
+    <Dialog open={props.open} onClose={props.onClose}>
+      <DialogTitle>Delete a volume permanently</DialogTitle>
+      <DialogContent>
+        <Backdrop
+          sx={{
+            backgroundColor: "rgba(245,244,244,0.4)",
+            zIndex: (theme) => theme.zIndex.drawer + 1,
+          }}
+          open={actionInProgress}
+        >
+          <CircularProgress color="info" />
+        </Backdrop>
+        <DialogContentText>The volume will be deleted permanently. This action cannot be undone. Are you sure?</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}>Cancel</Button>
+        <Button onClick={deleteVolume}>
+          Delete forever
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/ImportDialog.tsx
+++ b/ui/src/components/ImportDialog.tsx
@@ -1,142 +1,139 @@
-import React, { useContext } from "react";
-import {
-  Button,
-  Typography,
-  Grid,
-  Backdrop,
-  CircularProgress,
-} from "@mui/material";
+import React, {useContext} from "react";
+import {Backdrop, Button, CircularProgress, Grid, Typography,} from "@mui/material";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
-import { createDockerDesktopClient } from "@docker/extension-api-client";
+import {createDockerDesktopClient} from "@docker/extension-api-client";
 
-import { MyContext } from "../index";
-import { isError } from "../common/isError";
+import {MyContext} from "../index";
+import {isError} from "../common/isError";
 
 const client = createDockerDesktopClient();
 
 function useDockerDesktopClient() {
-  return client;
+    return client;
 }
 
-export default function ImportDialog({ ...props }) {
-  console.log("ImportDialog component rendered.");
-  const ddClient = useDockerDesktopClient();
+export default function ImportDialog({...props}) {
+    console.log("ImportDialog component rendered.");
+    const ddClient = useDockerDesktopClient();
 
-  const context = useContext(MyContext);
-  const fileName = `${context.store.volumeName}.tar.gz`;
+    const context = useContext(MyContext);
+    const fileName = `${context.store.volumeName}.tar.gz`;
 
-  const [path, setPath] = React.useState<string>("");
-  const [actionInProgress, setActionInProgress] =
-    React.useState<boolean>(false);
+    const [path, setPath] = React.useState<string>("");
+    const [actionInProgress, setActionInProgress] =
+        React.useState<boolean>(false);
 
-  const selectImportTarGzFile = () => {
-    ddClient.desktopUI.dialog
-      .showOpenDialog({
-        properties: ["openFile"],
-        filters: [{ name: ".tar.gz", extensions: ["tar.gz"] }], // should contain extension without wildcards or dots
-      })
-      .then((result) => {
-        if (result.canceled) {
-          return;
-        }
+    const selectImportTarGzFile = () => {
+        ddClient.desktopUI.dialog
+            .showOpenDialog({
+                properties: ["openFile"],
+                filters: [{name: ".tar.gz", extensions: ["tar.gz"]}], // should contain extension without wildcards or dots
+            })
+            .then((result) => {
+                if (result.canceled) {
+                    return;
+                }
 
-        setPath(result.filePaths[0]);
-      });
-  };
+                setPath(result.filePaths[0]);
+            });
+    };
 
-  const importVolume = async () => {
-    setActionInProgress(true);
+    const importVolume = async () => {
+        setActionInProgress(true);
+        let actionSuccessfullyCompleted = false
 
-    try {
-      const output = await ddClient.docker.cli.exec("run", [
-        "--rm",
-        `-v=${context.store.volumeName}:/vackup-volume `,
-        `-v=${path}:/vackup `, // path: e.g. "$HOME/Downloads/my-vol.tar.gz"
-        "busybox",
-        "tar",
-        "-xvzf",
-        `/vackup`,
-      ]);
-      if (isError(output.stderr)) {
-        ddClient.desktopUI.toast.error(output.stderr);
-        return;
-      }
-      ddClient.desktopUI.toast.success(
-        `File ${fileName} imported into volume ${context.store.volumeName}`
-      );
-    } catch (error) {
-      ddClient.desktopUI.toast.error(
-        `Failed to import file ${fileName} into volume ${context.store.volumeName}: ${error.stderr} Exit code: ${error.code}`
-      );
-    } finally {
-      setActionInProgress(false);
-      setPath("");
-      props.onClose();
-    }
-  };
+        try {
+            const output = await ddClient.docker.cli.exec("run", [
+                "--rm",
+                `-v=${context.store.volumeName}:/vackup-volume `,
+                `-v=${path}:/vackup `, // path: e.g. "$HOME/Downloads/my-vol.tar.gz"
+                "busybox",
+                "tar",
+                "-xvzf",
+                `/vackup`,
+            ]);
+            if (isError(output.stderr)) {
+                ddClient.desktopUI.toast.error(output.stderr);
+                return;
+            }
+            ddClient.desktopUI.toast.success(
+                `File ${fileName} imported into volume ${context.store.volumeName}`
+            );
 
-  return (
-    <Dialog open={props.open} onClose={props.onClose}>
-      <DialogTitle>Import gzip'ed tarball into a volume</DialogTitle>
-      <DialogContent>
-        <Backdrop
-          sx={{
-            backgroundColor: "rgba(245,244,244,0.4)",
-            zIndex: (theme) => theme.zIndex.drawer + 1,
-          }}
-          open={actionInProgress}
-        >
-          <CircularProgress color="info" />
-        </Backdrop>
-        <DialogContentText>
-          Extracts a gzip'ed tarball into a volume.
-        </DialogContentText>
-
-        <Grid container direction="column" spacing={2}>
-          <Grid item>
-            <Typography variant="body1" color="text.secondary" sx={{ mt: 2 }}>
-              Choose a .tar.gz to import, e.g. file.tar.gz
-            </Typography>
-          </Grid>
-          <Grid item>
-            <Button variant="contained" onClick={selectImportTarGzFile}>
-              Select file
-            </Button>
-          </Grid>
-
-          {path !== "" && (
-            <Grid item>
-              <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
-                The file {path} will be imported into volume{" "}
-                {context.store.volumeName}.
-              </Typography>
-              <Typography variant="body1" color="text.secondary">
-                ⚠️ This will replace all the existing data inside the volume.
-              </Typography>
-            </Grid>
-          )}
-        </Grid>
-      </DialogContent>
-      <DialogActions>
-        <Button
-          onClick={() => {
+            actionSuccessfullyCompleted = true
+        } catch (error) {
+            ddClient.desktopUI.toast.error(
+                `Failed to import file ${fileName} into volume ${context.store.volumeName}: ${error.stderr} Exit code: ${error.code}`
+            );
+        } finally {
+            setActionInProgress(false);
             setPath("");
-            props.onClose();
-          }}
-        >
-          Cancel
-        </Button>
-        <Button
-          onClick={importVolume}
-          disabled={path === "" || fileName === ""}
-        >
-          Import
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
+            props.onClose(actionSuccessfullyCompleted)
+        }
+    };
+
+    return (
+        <Dialog open={props.open} onClose={props.onClose}>
+            <DialogTitle>Import gzip'ed tarball into a volume</DialogTitle>
+            <DialogContent>
+                <Backdrop
+                    sx={{
+                        backgroundColor: "rgba(245,244,244,0.4)",
+                        zIndex: (theme) => theme.zIndex.drawer + 1,
+                    }}
+                    open={actionInProgress}
+                >
+                    <CircularProgress color="info"/>
+                </Backdrop>
+                <DialogContentText>
+                    Extracts a gzip'ed tarball into a volume.
+                </DialogContentText>
+
+                <Grid container direction="column" spacing={2}>
+                    <Grid item>
+                        <Typography variant="body1" color="text.secondary" sx={{mt: 2}}>
+                            Choose a .tar.gz to import, e.g. file.tar.gz
+                        </Typography>
+                    </Grid>
+                    <Grid item>
+                        <Button variant="contained" onClick={selectImportTarGzFile}>
+                            Select file
+                        </Button>
+                    </Grid>
+
+                    {path !== "" && (
+                        <Grid item>
+                            <Typography variant="body1" color="text.secondary" sx={{mb: 2}}>
+                                The file {path} will be imported into volume{" "}
+                                {context.store.volumeName}.
+                            </Typography>
+                            <Typography variant="body1" color="text.secondary">
+                                ⚠️ This will replace all the existing data inside the volume.
+                            </Typography>
+                        </Grid>
+                    )}
+                </Grid>
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    onClick={() => {
+                        setPath("");
+                        props.onClose(false)
+                    }}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={importVolume}
+                    disabled={path === "" || fileName === ""}
+                >
+                    Import
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
 }

--- a/ui/src/components/LoadDialog.tsx
+++ b/ui/src/components/LoadDialog.tsx
@@ -34,6 +34,7 @@ export default function LoadDialog({ ...props }) {
 
   const loadImage = async () => {
     setActionInProgress(true);
+    let actionSuccessfullyCompleted = false
 
     try {
       const output = await ddClient.docker.cli.exec("run", [
@@ -52,6 +53,8 @@ export default function LoadDialog({ ...props }) {
       ddClient.desktopUI.toast.success(
         `Copied /volume-data from image ${imageName} into volume ${context.store.volumeName}`
       );
+
+      actionSuccessfullyCompleted = true
     } catch (error) {
       ddClient.desktopUI.toast.error(
         `Failed to copy /volume-data from image ${imageName} to into volume ${context.store.volumeName}: ${error.stderr} Exit code: ${error.code}`
@@ -59,7 +62,7 @@ export default function LoadDialog({ ...props }) {
     } finally {
       setActionInProgress(false);
       setImageName("");
-      props.onClose();
+      props.onClose(actionSuccessfullyCompleted)
     }
   };
 
@@ -120,7 +123,7 @@ export default function LoadDialog({ ...props }) {
         <Button
           onClick={() => {
             setImageName("");
-            props.onClose();
+            props.onClose(false);
           }}
         >
           Cancel


### PR DESCRIPTION
In this PR:

- Do not use `system df` to get the size of the volumes as it is a slow operation and there can't be two operations running simultaneously. Instead, run a container per volume which executes a `du` command to check its size.

- Add a progress bar when calculating a volume size.

- Do not fetch the list of volumes when canceling an action.

- Fixes #4 