### PR TITLE
Do not use `/var/run/docker.sock.raw`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,4 +3,4 @@ services:
     image: ${DESKTOP_PLUGIN_IMAGE}
     restart: unless-stopped
     volumes:
-      - /var/run/docker.sock.raw:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/vm/internal/handler/export.go
+++ b/vm/internal/handler/export.go
@@ -33,20 +33,6 @@ func (h *Handler) ExportVolume(ctx echo.Context) error {
 	log.Infof("path: %s", path)
 	log.Infof("fileName: %s", fileName)
 
-	if strings.Contains(path, ":") {
-		// Fix Windows path
-		// e.g. from C:\Users\felipe\Downloads to /c/Users/felipe/Downloads
-		path = strings.Replace(path, "C:\\", "/c/", 1)
-		path = strings.Replace(path, "\\", "/", -1)
-		// At the moment, we assume Docker Desktop uses the WSL backend is enabled.
-		// The mount points with WSL are in "/run/desktop/mnt/host/"
-		// e.g. "/run/desktop/mnt/host/c/Users/felipe/Downloads"
-		path = "/run/desktop/mnt/host" + path
-		// TODO: Support Hyper-V
-	}
-
-	log.Infof("path replaced: %s", path)
-
 	// Stop container(s)
 	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, volumeName)
 	if err != nil {

--- a/vm/internal/handler/export_test.go
+++ b/vm/internal/handler/export_test.go
@@ -26,13 +26,7 @@ func TestExportVolume(t *testing.T) {
 	var containerID string
 	volume := "2f91f352f0ba381893b9e15ea87db0e28a88aa6e28070c07892681d7a0d6ba6b"
 	cli := setupDockerClient(t)
-
-	var tmpDir string
-	if runtime.GOOS == "windows" {
-		tmpDir = `C:\Users\felipe\Downloads`
-	} else {
-		tmpDir = os.TempDir()
-	}
+	tmpDir := os.TempDir()
 
 	defer func() {
 		_ = cli.ContainerRemove(context.Background(), containerID, types.ContainerRemoveOptions{

--- a/vm/internal/handler/import.go
+++ b/vm/internal/handler/import.go
@@ -3,14 +3,12 @@ package handler
 import (
 	"bytes"
 	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/felipecruz91/vackup-docker-extension/internal/backend"
 	"github.com/felipecruz91/vackup-docker-extension/internal/log"
 	"github.com/labstack/echo"
+	"net/http"
 )
 
 func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
@@ -26,20 +24,6 @@ func (h *Handler) ImportTarGzFile(ctx echo.Context) error {
 
 	log.Infof("volumeName: %s", volumeName)
 	log.Infof("path: %s", path)
-
-	if strings.Contains(path, ":") {
-		// Fix Windows path
-		// e.g. from C:\Users\felipe\Downloads to /c/Users/felipe/Downloads
-		path = strings.Replace(path, "C:\\", "/c/", 1)
-		path = strings.Replace(path, "\\", "/", -1)
-		// At the moment, we assume Docker Desktop uses the WSL backend is enabled.
-		// The mount points with WSL are in "/run/desktop/mnt/host/"
-		// e.g. "/run/desktop/mnt/host/c/Users/felipe/Downloads"
-		path = "/run/desktop/mnt/host" + path
-		// TODO: Support Hyper-V
-	}
-
-	log.Infof("path replaced: %s", path)
 
 	// Stop container(s)
 	stoppedContainers, err := backend.StopContainersAttachedToVolume(ctx.Request().Context(), h.DockerClient, volumeName)


### PR DESCRIPTION
Because I was using the `/var/run/docker.sock.raw` instead of `/var/run/docker.sock`, I was bypassing the docker proxy and the translation of the host path to the VM path was not carried out.

Now the bind mounts work on Linux.