### PR TITLE
Return volume size as a numeric byte count

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -33,7 +33,8 @@ function useDockerDesktopClient() {
 
 type VolumeData = {
     Driver: string;
-    Size: string;
+    Size: number;
+    SizeHuman: string;
     Containers: string[];
 };
 
@@ -152,7 +153,7 @@ export function App() {
                     }
                     label="Export volume"
                     onClick={handleExport(params.row)}
-                    disabled={params.row.volumeSize === "0B"}
+                    disabled={params.row.volumeSize === "0 B"}
                 />,
                 <GridActionsCellItem
                     key={"action_import_" + params.row.id}
@@ -174,7 +175,7 @@ export function App() {
                     label="Save to image"
                     onClick={handleSave(params.row)}
                     showInMenu
-                    disabled={params.row.volumeSize === "0B"}
+                    disabled={params.row.volumeSize === "0 B"}
                 />,
                 <GridActionsCellItem
                     key={"action_load_" + params.row.id}
@@ -197,7 +198,7 @@ export function App() {
                     label="Transfer to host"
                     onClick={handleTransfer(params.row)}
                     showInMenu
-                    disabled={params.row.volumeSize === "0B"}
+                    disabled={params.row.volumeSize === "0 B"}
                 />,
                 <GridActionsCellItem
                     key={"action_empty_" + params.row.id}
@@ -209,7 +210,7 @@ export function App() {
                     label="Empty volume"
                     onClick={handleEmpty(params.row)}
                     showInMenu
-                    disabled={params.row.volumeSize === "0B"}
+                    disabled={params.row.volumeSize === "0 B"}
                 />,
                 <GridActionsCellItem
                     key={"action_delete_" + params.row.id}
@@ -292,6 +293,7 @@ export function App() {
                     .then((results: Record<string, VolumeData>) => {
                         let rows = [];
                         let index = 0;
+                        console.log(results)
 
                         for (const key in results) {
                             const value = results[key];
@@ -300,7 +302,7 @@ export function App() {
                                 volumeDriver: value.Driver,
                                 volumeName: key,
                                 volumeContainers: value.Containers,
-                                volumeSize: value.Size,
+                                volumeSize: value.SizeHuman,
                             });
                             index++;
                         }
@@ -431,12 +433,15 @@ export function App() {
         try {
             ddClient.extension.vm.service
                 .get(`/volumes/${volumeName}/size`)
-                .then((size: string) => {
+                .then((res: any) => {
+                    // e.g. {"Bytes":16000,"Human":"16.0 kB"}
+                    const resJSON = JSON.stringify(res)
+                    const sizeObj = JSON.parse(resJSON)
                     let rowsCopy = rows.slice(); // copy the array
                     const index = rowsCopy.findIndex(
                         (element) => element.volumeName === volumeName
                     );
-                    rowsCopy[index].volumeSize = size;
+                    rowsCopy[index].volumeSize = sizeObj.Human;
 
                     setRows(rowsCopy);
 

--- a/vm/internal/handler/import_test.go
+++ b/vm/internal/handler/import_test.go
@@ -56,5 +56,6 @@ func TestImportTarGzFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
 	sizes := backend.GetVolumesSize(c.Request().Context(), cli, volume)
-	require.Regexp(t, ".*K", sizes[volume])
+	require.Equal(t, int64(16000), sizes[volume].Bytes)
+	require.Equal(t, "16.0 kB", sizes[volume].Human)
 }

--- a/vm/internal/handler/load_test.go
+++ b/vm/internal/handler/load_test.go
@@ -69,6 +69,7 @@ func TestLoadImage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
 	sizes := backend.GetVolumesSize(c.Request().Context(), cli, volume)
-	t.Logf("Volume size after loading image into it: %s", sizes[volume])
-	require.Regexp(t, ".*K", sizes[volume])
+	t.Logf("Volume size after loading image into it: %+v", sizes[volume])
+	require.Equal(t, int64(16000), sizes[volume].Bytes)
+	require.Equal(t, "16.0 kB", sizes[volume].Human)
 }

--- a/vm/internal/handler/size_test.go
+++ b/vm/internal/handler/size_test.go
@@ -80,5 +80,6 @@ func TestVolumeSize(t *testing.T) {
 	t.Log(size)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Regexp(t, "\".*K\"\n", size)
+	require.Equal(t, `{"Bytes":16000,"Human":"16.0 kB"}
+`, size)
 }

--- a/vm/internal/handler/volumes.go
+++ b/vm/internal/handler/volumes.go
@@ -17,7 +17,8 @@ type VolumesResponse struct {
 
 type VolumeData struct {
 	Driver     string
-	Size       string
+	Size       int64
+	SizeHuman  string
 	Containers []string
 }
 
@@ -41,11 +42,13 @@ func (h *Handler) Volumes(ctx echo.Context) error {
 		entry, ok := res.data[k]
 		if !ok {
 			res.data[k] = VolumeData{
-				Size: v,
+				Size:      v.Bytes,
+				SizeHuman: v.Human,
 			}
 			continue
 		}
-		entry.Size = v
+		entry.Size = v.Bytes
+		entry.SizeHuman = v.Human
 		res.data[k] = entry
 	}
 	res.Unlock()

--- a/vm/internal/handler/volumes_test.go
+++ b/vm/internal/handler/volumes_test.go
@@ -49,7 +49,8 @@ func TestVolumes(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, m, volume)
 	require.Equal(t, "local", m[volume].Driver)
-	require.Equal(t, "0B", m[volume].Size)
+	require.Equal(t, int64(0), m[volume].Size)
+	require.Equal(t, "0 B", m[volume].SizeHuman)
 	require.Len(t, m[volume].Containers, 0)
 }
 

--- a/vm/internal/log/log.go
+++ b/vm/internal/log/log.go
@@ -27,6 +27,10 @@ func Error(args ...interface{}) {
 	logger.Error(args...)
 }
 
+func Warn(args ...interface{}) {
+	logger.Warn(args...)
+}
+
 func Warnf(format string, args ...interface{}) {
 	logger.Warnf(format, args...)
 }


### PR DESCRIPTION
Originally the size returned by the backend was in human-readable format (e.g. 16.0 kB).

Now the backend returns both the byte count and the human-readable representation of the size of the volume: `{"Bytes":16000,"Human":"16.0 kB"}`


The human-readable is used in the size column of the table.

![image](https://user-images.githubusercontent.com/15997951/182587746-f4efacff-a2d3-4af9-a1d9-12cf686a7cdb.png)
